### PR TITLE
Error handling

### DIFF
--- a/classes/class-seriously-simple-podcasting.php
+++ b/classes/class-seriously-simple-podcasting.php
@@ -532,7 +532,10 @@ class SeriouslySimplePodcasting {
 
 			$data = wp_remote_head( $file );
 
-			if( isset( $data['headers']['content-length'] ) ) {
+			if(is_wp_error($data))
+				die($data->get_error_message());
+
+			if( !is_wp_error($data) && isset( $data['headers']['content-length'] ) ) {
 
 				$raw = $data['headers']['content-length'];
 				$formatted = $this->format_bytes( $raw );


### PR DESCRIPTION
If a WP_Error is thrown the plugin breaks without letting the user know why. This 1) prevents an error of handling an object as an array and 2) displays a WP_Error instead.