### PR TITLE
Added wp_current_filter check

### DIFF
--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -76,7 +76,12 @@ class SSP_Frontend {
 	 * @return string          Updated episode content
 	 */
 	public function content_meta_data( $content ) {
-		global $post;
+		global $post, $wp_current_filter;
+
+		// Don't output unformatted data on excerpts.
+		if ( in_array( 'get_the_excerpt', (array) $wp_current_filter ) ) {
+			return $content;
+		}
 
 		$podcast_post_types = get_option( 'ss_podcasting_use_post_types', array() );
 		$podcast_post_types[] = $this->token;


### PR DESCRIPTION
This should prevent the unformatted shortcode data from being displayed in excerpts. I think in general this function could use some more checking to account for other weird use cases, but this does seem to do the trick for now.

For a good example of additional checks that should probably be added, take a look at this function in Jetpack:
https://github.com/Automattic/jetpack/blob/5fc81afe593f0ee1fa14c4a1f48440e5ab11a59f/modules/sharedaddy/sharing-service.php#L491-L636