### PR TITLE
Bug: forming SQL statement due to %s followed by a space

### DIFF
--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -437,7 +437,7 @@ class SSP_Frontend {
 
 		    $prefix = $wpdb->prefix;
 
-		    $sql = 'SELECT ID FROM %s posts WHERE guid="%s";';
+		    $sql = 'SELECT ID FROM %sposts WHERE guid="%s";';
 		    $prepped = $wpdb->prepare( $sql, array( $prefix, esc_url_raw( $attachment ) ) );
 		    $attachment = $wpdb->get_col( $prepped );
 


### PR DESCRIPTION
The bug is as follows:
`$sql = 'SELECT ID FROM %s posts WHERE guid="%s";';`
`$prepped = $wpdb->prepare( $sql, array( $prefix, esc_url_raw( $attachment ) ) );`

This seems to result in the SQL statement:
`SELECT ID FROM wp_ posts WHERE guid="whatever";`

Notice the space between the table prefix and the post table name. (That's what I'm seeing in some site error logs since updating the plugin, anyway.)

I'm not entirely sure if my proposed change will fix it – my knowledge of how sprintf handles arguments isn't authoritative!