### PR TITLE
Let's try that fix again!

### DIFF
--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -435,9 +435,7 @@ class SSP_Frontend {
 		if ( $attachment ) {
 		    global $wpdb;
 
-		    $prefix = $wpdb->prefix;
-
-		    $sql = 'SELECT ID FROM $wpdb->posts WHERE guid = %s';
+		    $sql = "SELECT ID FROM $wpdb->posts WHERE guid = %s";
 		    $prepped = $wpdb->prepare( $sql, esc_url_raw( $attachment ) );
 		    $attachment = $wpdb->get_col( $prepped );
 

--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -437,8 +437,8 @@ class SSP_Frontend {
 
 		    $prefix = $wpdb->prefix;
 
-		    $sql = 'SELECT ID FROM %sposts WHERE guid="%s";';
-		    $prepped = $wpdb->prepare( $sql, array( $prefix, esc_url_raw( $attachment ) ) );
+		    $sql = 'SELECT ID FROM $wpdb->posts WHERE guid = %s';
+		    $prepped = $wpdb->prepare( $sql, esc_url_raw( $attachment ) );
 		    $attachment = $wpdb->get_col( $prepped );
 
 		    if ( isset( $attachment[0] ) ) {


### PR DESCRIPTION
Sorry, Hugh, I'm afraid that last fix didn't take: unfortunately, and probably sensibly, the `prepare` function automatically quotes anything provided to it:

http://codex.wordpress.org/Data_Validation#Database
>$format is a sprintf() like format string. It only understands %s, %d and %f, none of which need to be enclosed in quotation marks.

The generated statement from the previous fix looks something like this:
`SELECT ID FROM 'wp_'posts WHERE guid='whatever';`

The new proposed fix uses the `$wpdb->posts` link to get the post table, which I've seen in several examples in the documentation and in the WordPress source itself, so it should be pretty safe. I've also removed the double-quotes from inside the `$sql` string as they're unnecessary.

I'm pretty sure that's all correct now, but if you could double-check it that'd be great.

Thanks again! Sorry for the extra point release.