### PR TITLE
Multiple Feeds Redirection

### DIFF
--- a/includes/class-ssp-settings.php
+++ b/includes/class-ssp-settings.php
@@ -783,7 +783,7 @@ class SSP_Settings {
 				break;
 
 				default:
-					$html .= '<label for="' . esc_attr( $field['id'] ) . '"><span class="description">' . esc_html( $field['description'] ) . '</span></label>' . "\n";
+					$html .= '<label for="' . esc_attr( $field['id'] ) . '"><span class="description">' . wp_kses_post( $field['description'] ) . '</span></label>' . "\n";
 				break;
 			}
 		}

--- a/includes/class-ssp-settings.php
+++ b/includes/class-ssp-settings.php
@@ -359,7 +359,7 @@ class SSP_Settings {
 					'description'	=> sprintf( __( 'Redirect your feed to a new URL (specified below).%1$sThis will inform all podcasting services that your podcast has moved and 48 hours after you have saved this option it will permanently redirect your feed to the new URL.', 'ss-podcasting' ) , '<br/>' ),
 					'type'			=> 'checkbox',
 					'default'		=> '',
-					'callback'		=> 'esc_url_raw',
+					'callback'		=> 'wp_strip_all_tags',
 				),
 				array(
 					'id' 			=> 'new_feed_url',

--- a/includes/class-ssp-settings.php
+++ b/includes/class-ssp-settings.php
@@ -353,6 +353,24 @@ class SSP_Settings {
 					'default'		=> '',
 					'callback'		=> 'wp_strip_all_tags',
 				),
+				array(
+					'id' 			=> 'redirect_feed',
+					'label'			=> __( 'Redirect podcast feed to new URL', 'ss-podcasting' ),
+					'description'	=> sprintf( __( 'Redirect your feed to a new URL (specified below).%1$sThis will inform all podcasting services that your podcast has moved and 48 hours after you have saved this option it will permanently redirect your feed to the new URL.', 'ss-podcasting' ) , '<br/>' ),
+					'type'			=> 'checkbox',
+					'default'		=> '',
+					'callback'		=> 'esc_url_raw',
+				),
+				array(
+					'id' 			=> 'new_feed_url',
+					'label'			=> __( 'New podcast feed URL', 'ss-podcasting' ),
+					'description'	=> __( 'Your podcast feed\'s new URL.', 'ss-podcasting' ),
+					'type'			=> 'text',
+					'default'		=> '',
+					'placeholder'	=> __( 'New feed URL', 'ss-podcasting' ),
+					'callback'		=> 'esc_url_raw',
+					'class'			=> 'regular-text',
+				),
 			)
 		);
 

--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -90,6 +90,22 @@ if ( $podcast_series ) {
 	$series_id = $series->term_id;
 }
 
+// Do we need to redirect a single feed?
+if ( $podcast_series ) {
+	$redirect = get_option( 'ss_podcasting_redirect_feed_' . $series_id );
+	$new_feed_url = false;
+	if ( $redirect && $redirect == 'on' ) {
+		$new_feed_url = get_option( 'ss_podcasting_new_feed_url_' . $series_id );
+		if ( $new_feed_url ) {
+			header ( 'HTTP/1.1 301 Moved Permanently' );
+			header ( 'Location: ' . $new_feed_url );
+			exit;
+		}
+	}
+
+}
+
+
 // Podcast title
 $title = get_option( 'ss_podcasting_data_title', get_bloginfo( 'name' ) );
 if ( $podcast_series ) {


### PR DESCRIPTION
Brought up an issue a little while ago here https://github.com/hlashbrooke/Seriously-Simple-Podcasting/issues/54 that it would be good to have an option to redirect individual feeds. This adds that feature. This also changes `esc_html()` to `wp_kses_post()` in one instance where we want some HTML to come through.