### PR TITLE
Only enqueeeueue media on post pages

### DIFF
--- a/includes/class-ssp-settings.php
+++ b/includes/class-ssp-settings.php
@@ -85,7 +85,10 @@ class SSP_Settings {
 	 * @return void
 	 */
 	public function enqueue_scripts() {
-		wp_enqueue_media();
+		global $pagenow;
+		if ( in_array( $pagenow, array( 'post-new.php', 'post.php' ) ) ) {
+			wp_enqueue_media();
+		}
 	}
 
 	/**


### PR DESCRIPTION
We are seeing a lot of slow queries on pages where this isn't needed, like dashboard and edit pages. Let's limit the functionality to just the edit pages.