### PR TITLE
Bail out a lot faster if the context is the glance.

### DIFF
--- a/includes/class-ssp-admin.php
+++ b/includes/class-ssp-admin.php
@@ -583,7 +583,7 @@ class SSP_Admin {
 	 */
 	public function glance_items( $items = array() ) {
 
-		$num_posts = count( ssp_episodes( -1, '', false, 'glance' ) );
+		$num_posts = ssp_episodes( -1, '', false, 'glance' );
 
 		$post_type_object = get_post_type_object( $this->token );
 

--- a/includes/class-ssp-admin.php
+++ b/includes/class-ssp-admin.php
@@ -583,7 +583,7 @@ class SSP_Admin {
 	 */
 	public function glance_items( $items = array() ) {
 
-		$num_posts = ssp_episodes( -1, '', false, 'glance' );
+		$num_posts = count( ssp_episodes( -1, '', false, 'glance' ) );
 
 		$post_type_object = get_post_type_object( $this->token );
 

--- a/includes/ssp-functions.php
+++ b/includes/ssp-functions.php
@@ -293,8 +293,8 @@ if ( ! function_exists( 'ssp_episodes' ) ) {
 		// Get all podcast episodes IDs
 		$episode_ids = (array) ssp_episode_ids();
 
-		if ( $context == 'glance' ) {
-			return count( $episode_ids );
+		if ( $context === 'glance' ) {
+			return $episode_ids;
 		}
 
 		if ( empty( $episode_ids ) ) {

--- a/includes/ssp-functions.php
+++ b/includes/ssp-functions.php
@@ -293,6 +293,10 @@ if ( ! function_exists( 'ssp_episodes' ) ) {
 		// Get all podcast episodes IDs
 		$episode_ids = (array) ssp_episode_ids();
 
+		if ( $context == 'glance' ) {
+			return count( $episode_ids );
+		}
+
 		if ( empty( $episode_ids ) ) {
 			return array();
 		}


### PR DESCRIPTION
This code can get really out of hand for sites with a lot of podcasts.

We should add a lot of caching around these functions too.