### PR TITLE
Need to ensure that we exit out, so that we don't loop in other processes.

### DIFF
--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -736,10 +736,11 @@ class SSP_Frontend {
 
 			        // Use ssp_readfile_chunked() if allowed on the server or simply access file directly
 					@ssp_readfile_chunked( "$file" ) or header( 'Location: ' . $file );
-
+					exit();
 				} else {
 					// For all other referrers simply access the file directly
-					header( 'Location: ' . $file );
+					wp_redirect( $file, 302 );
+					exit();
 				}
 
 			}


### PR DESCRIPTION
Also use `wp_redirect()` to handle the header.