### PR TITLE
ref - fix for custom feed templates will never work with child themes.

### DIFF
--- a/includes/class-ssp-admin.php
+++ b/includes/class-ssp-admin.php
@@ -806,7 +806,7 @@ class SSP_Admin {
 
     	$file_name = 'feed-podcast.php';
 
-    	$user_template_file = apply_filters( 'ssp_feed_template_file', trailingslashit( get_template_directory() ) . $file_name );
+    	$user_template_file = apply_filters( 'ssp_feed_template_file', trailingslashit( get_stylesheet_directory() ) . $file_name );
 
 		// Any functions hooked in here must NOT output any data or else feed will break
 		do_action( 'ssp_before_feed' );


### PR DESCRIPTION
https://wordpress.org/support/topic/white-space-at-start-of-podcast-feed?replies=3

in debugging I did find that class-ssp-admin.php line 809 uses get_template_directory() this doesn't work for child theme custom feed templates. It really needs swapping out to use
$user_template_file = apply_filters( 'ssp_feed_template_file', trailingslashit( get_stylesheet_directory() ) . $file_name );