### PR TITLE
Mark episodes explicit if the entire podcast is

### DIFF
--- a/includes/class-ssp-admin.php
+++ b/includes/class-ssp-admin.php
@@ -647,7 +647,7 @@ class SSP_Admin {
 		    'name' => __( 'Explicit:' , 'seriously-simple-podcasting' ),
 		    'description' => __( 'Mark this episode as explicit.' , 'seriously-simple-podcasting' ),
 		    'type' => 'checkbox',
-		    'default' => '',
+		    'default' => get_option( 'ss_podcasting_explicit' ),
 		    'section' => 'info',
 		);
 


### PR DESCRIPTION
A bit of a semantic addition;

When an entire podcast is labeled explicit, each of their episodes should be, by default. This change reads the global podcast options, and if the podcast is explicit, automatically checks the box for each episode as well.