### PR TITLE
Report Filesize on Podcast Download

### DIFF
--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -913,11 +913,11 @@ class SSP_Frontend {
 				header( "Content-Transfer-Encoding: binary" );
 
 				// Set size of file
-			if ( $size = @filesize( $file ) ) {
-				header( "Content-Length: " . $size );
-			} else if ( $size = get_post_meta( $episode_id, "filesize_raw", true) ) {
-				header( "Content-Length: " . $size );
-			}
+				if ( $size = get_post_meta( $episode_id, "filesize_raw", true) ) {
+					header( "Content-Length: " . $size );
+				} else if ( $size = @filesize( $file ) ) {
+					header( "Content-Length: " . $size );
+				}
 
 		        // Check file referrer
 		        if( 'download' == $referrer ) {

--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -913,9 +913,11 @@ class SSP_Frontend {
 				header( "Content-Transfer-Encoding: binary" );
 
 				// Set size of file
-		        if ( $size = @filesize( $file ) ) {
-		        	header( "Content-Length: " . $size );
-		        }
+			if ( $size = @filesize( $file ) ) {
+				header( "Content-Length: " . $size );
+			} else if ( $size = get_post_meta( $episode_id, "filesize_raw", true) ) {
+				header( "Content-Length: " . $size );
+			}
 
 		        // Check file referrer
 		        if( 'download' == $referrer ) {


### PR DESCRIPTION
The Content-Length header was not being included on the podcast download, since the $file is a URL.  I don't know if this is the best way to handle it, but it works for me.  I wondered if there was a way to use $this->get_file_size(...) but that looked like it downloads the file from the URL to find its size - not too efficient?  I just used the saved value from the saved meta information.