### PR TITLE
Allow podcasts to live outside of the WordPress installation (Issue #101)

### DIFF
--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -466,6 +466,9 @@ class SSP_Frontend {
 				require_once( ABSPATH . 'wp-admin/includes/media.php' );
 			}
 
+			// translate file URL to local file path if possible
+			$file = $this->get_local_file_path( $file );
+
 			// Get file data (for local file)
 			$data = wp_read_audio_metadata( $file );
 
@@ -514,9 +517,8 @@ class SSP_Frontend {
 				require_once( ABSPATH . 'wp-admin/includes/media.php' );
 			}
 
-			// Identify file by root path and not URL (required for getID3 class)
-			$site_root = trailingslashit( ABSPATH );
-			$file = str_replace( $this->site_url, $site_root, $file );
+			// translate file URL to local file path if possible
+			$file = $this->get_local_file_path( $file );
 
 			// Get file data (will only work for local files)
 			$data = wp_read_audio_metadata( $file );
@@ -1127,4 +1129,38 @@ class SSP_Frontend {
 	    return $html;
 	}
 
+	/**
+	 * Returns a local file path for the given file URL if it's local. Otherwise
+	 * returns the original URL
+	 *
+	 * @param    string    file
+	 * @return   string    file or local file path
+	 */
+	function get_local_file_path( $file ) {
+		// Identify file by root path and not URL (required for getID3 class)
+		$site_root = trailingslashit( ABSPATH );
+		// remove common dirs from the ends of site_url and site_root, so that
+		// file can be outside of the wordpress installation
+		$root_chunks = explode('/', $site_root);
+		$url_chunks  = explode('/', $this->site_url);
+
+		end($root_chunks);
+		end($url_chunks);
+
+		while (!is_null(key($root_chunks)) && !is_null(key($url_chunks)) &&
+			   (current($root_chunks) == current($url_chunks))) {
+
+			array_pop($root_chunks);
+			array_pop($url_chunks);
+
+			end($root_chunks);
+			end($url_chunks);
+		}
+		$site_root = implode('/', $root_chunks);
+		$site_url  = implode('/', $url_chunks);
+
+		$file = str_replace( $site_url, $site_root, $file );
+		
+		return $file;
+	}
 }


### PR DESCRIPTION
This patch allows podcasts to live outside of the WordPress site_root. My WP site uses http://domain/wp/ for Wordpress, but the podcasts are in http://domain/podcasts/. I have used a symlink to fix this problem, but this patch eliminates the need for a symlink, and prevents failure if someone links to a file using the /podcasts directory.

Reported as Issue #101