### PR TITLE
Improve <image> output in feeds

### DIFF
--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -297,6 +297,9 @@ if( $stylehseet_url ) {
 	<itunes:new-feed-url><?php echo esc_url( $new_feed_url ); ?></itunes:new-feed-url>
 	<?php }
 
+	// Prevent WP core from outputting an <image> element
+	remove_action( 'rss2_head', 'rss2_site_icon' );
+
 	// Add RSS2 headers
 	do_action( 'rss2_head' );
 

--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -266,7 +266,11 @@ if( $stylehseet_url ) {
 	if ( $image ) {
 	?><itunes:image href="<?php echo esc_url( $image ); ?>"></itunes:image>
 	<googleplay:image href="<?php echo esc_url( $image ); ?>"></googleplay:image>
-	<image href="<?php echo esc_url( $image ); ?>"></image>
+	<image>
+		<url><?php echo esc_url( $image ); ?></url>
+		<title><?php echo esc_html( $title ); ?></title>
+		<link><?php echo esc_url( apply_filters( 'ssp_feed_channel_link_tag', $ss_podcasting->home_url, $podcast_series ) ) ?></link>
+	</image>
 	<?php } ?>
 	<?php if ( isset( $category1['category'] ) && $category1['category'] ) { ?>
 	<itunes:category text="<?php echo esc_attr( $category1['category'] ); ?>">


### PR DESCRIPTION
Prevents WP core from outputting an `<image>` element, and improves our `<image>` element output to conform to the [specification](https://cyber.law.harvard.edu/rss/rss.html)