### PR TITLE
Introduction of ssp_image filter, to allow control of the URL for image

### DIFF
--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -211,6 +211,9 @@ if ( $podcast_series ) {
 	}
 }
 
+// Image URL (filterable to allow custom images)
+$image = apply_filters( 'ssp_image', $image );
+
 // Podcast category and subcategory (all levels)
 $category1 = ssp_get_feed_category_output( 1, $series_id );
 $category2 = ssp_get_feed_category_output( 2, $series_id );

--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -212,7 +212,7 @@ if ( $podcast_series ) {
 }
 
 // Image URL (filterable to allow custom images)
-$image = apply_filters( 'ssp_feed_image', $image );
+$image = apply_filters( 'ssp_feed_image', $image, $series_id );
 
 // Podcast category and subcategory (all levels)
 $category1 = ssp_get_feed_category_output( 1, $series_id );

--- a/templates/feed-podcast.php
+++ b/templates/feed-podcast.php
@@ -212,7 +212,7 @@ if ( $podcast_series ) {
 }
 
 // Image URL (filterable to allow custom images)
-$image = apply_filters( 'ssp_image', $image );
+$image = apply_filters( 'ssp_feed_image', $image );
 
 // Podcast category and subcategory (all levels)
 $category1 = ssp_get_feed_category_output( 1, $series_id );


### PR DESCRIPTION
Hi There,

Great plugin, and thanks for your support!

I've had to fork it slightly so that it works for my site.

Some servers save image URL's as //domian.com/imageurl (i.e. without http or https).

This causes an invalidation error when submitting it to iTunes.

https://discussions.apple.com/message/30111090?ac_cid=op123456#30111090

I've introduced a filter, ssp_image, allowing you to modify the image. In my case, I can add https: before the URL so the feed validates.

Let me know if you have any questions...