### PR TITLE
If this from a legacy WordPress enclosure, ensure that we are getting…

### DIFF
--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -889,6 +889,16 @@ class SSP_Frontend {
 				// Get audio file for download
 				$file = $this->get_enclosure( $episode_id );
 
+				// Do we have newlines?
+				$parts = explode( "\n", $episode );
+
+				if ( is_array( $parts ) && count( $parts ) > 1 ) {
+					$file = $parts[0];
+				} else {
+					// Get audio file for download
+					$file = $this->get_enclosure( $episode_id );
+				}
+
 				// Exit if no file is found
 				if ( ! $file ) {
 					return;

--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -886,9 +886,6 @@ class SSP_Frontend {
 					return;
 				}
 
-				// Get audio file for download
-				$file = $this->get_enclosure( $episode_id );
-
 				// Do we have newlines?
 				$parts = explode( "\n", $episode );
 


### PR DESCRIPTION
… the correct URL.

Was seeing a response like this, and then throwing header errors.
```
http://sunstonemagazine.com/audio/SL15133.mp3
27371505
audio/mpeg
```