### PR TITLE
Bugfix: only set Content-Disposition headers when the file is downloaded directly

### DIFF
--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -912,9 +912,6 @@ class SSP_Frontend {
 				header( "Expires: 0" );
 				header( "Cache-Control: must-revalidate, post-check=0, pre-check=0" );
 				header( "Robots: none" );
-				header( "Content-Description: File Transfer" );
-				header( "Content-Disposition: attachment; filename=\"" . basename( $file ) . "\";" );
-				header( "Content-Transfer-Encoding: binary" );
 
 				// Set size of file
 				// Do we have anything in Cache/DB?
@@ -952,6 +949,11 @@ class SSP_Frontend {
 
 		        	// Force file download
 		        	header( "Content-Type: application/force-download" );
+
+							// Set other relevant headers
+							header( "Content-Description: File Transfer" );
+							header( "Content-Disposition: attachment; filename=\"" . basename( $file ) . "\";" );
+							header( "Content-Transfer-Encoding: binary" );
 
 			        // Use ssp_readfile_chunked() if allowed on the server or simply access file directly
 					@ssp_readfile_chunked( "$file" ) or header( 'Location: ' . $file );

--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -950,10 +950,10 @@ class SSP_Frontend {
 		        	// Force file download
 		        	header( "Content-Type: application/force-download" );
 
-							// Set other relevant headers
-							header( "Content-Description: File Transfer" );
-							header( "Content-Disposition: attachment; filename=\"" . basename( $file ) . "\";" );
-							header( "Content-Transfer-Encoding: binary" );
+			        // Set other relevant headers
+			        header( "Content-Description: File Transfer" );
+			        header( "Content-Disposition: attachment; filename=\"" . basename( $file ) . "\";" );
+			        header( "Content-Transfer-Encoding: binary" );
 
 			        // Use ssp_readfile_chunked() if allowed on the server or simply access file directly
 					@ssp_readfile_chunked( "$file" ) or header( 'Location: ' . $file );


### PR DESCRIPTION
Previously, the following 3 headers were set in all scenarios (either a direct download or a 301/302 HTTP redirect to the correct MP3):

```
Content-Description
Content-Disposition
Content-Transfer-Encoding
```

These headers should only be set when the file is parsed through PHP with the ```ssp_readfile_chunked``` function. If there's a redirect (because the referer is wrong), the headers above are actually invalid and should be removed.

This PR only sets the headers when the first code-path is being followed: the MP3 is being read by PHP and given to the client.

Ps; it doesn't catch the ```or``` scenario which handles the fallback in case the ```ssp_readfile_chunked``` fails, but it gets us halfway.