### PR TITLE
Add HTML5 Download Attribute to Download Links

### DIFF
--- a/includes/class-ssp-frontend.php
+++ b/includes/class-ssp-frontend.php
@@ -362,7 +362,7 @@ class SSP_Frontend {
 			switch( $key ) {
 
 				case 'link':
-					$meta_display .= '<a href="' . esc_url( $data ) . '" title="' . get_the_title() . ' ">' . __( 'Download file' , 'seriously-simple-podcasting' ) . '</a>';
+					$meta_display .= '<a href="' . esc_url( $data ) . '" title="' . get_the_title() . ' " download>' . __( 'Download file' , 'seriously-simple-podcasting' ) . '</a>';
 				break;
 
 				case 'new_window':


### PR DESCRIPTION
I love ApplyFilters by Pippin and Brad, but sometimes the airplane wifi doesn't love me as much. Thus I often download the podcast episodes. Right now, in Chrome on Windows, clicking the download link actually autoplays the audio file instead of downloading it. With the introduction of the HTML5 `download` attribute, this problem can be bypassed for most browsers in use. This PR adds the attribute to the download podcast links.

This tells moderner* browsers to download the file instead of trying to play it in browser without having to deal with setting up a more complicated header sending system which would work with all browsers.

Browser support:
Chrome 14+
Edge/IE 13+
FireFox: 20+
Opera: 15+
Safari: Well we're talking about Safari, so not supported at all. Yet. Maybe one day. Please Safari?

In case of a browser not supporting the attribute, it is simply ignored, thus making this a zero downside enhancement for modern browsers.

 `*` A word that is really not a word, but should be. Not because it is proper English but because it sounds cool.